### PR TITLE
Feature/kazuki gallery page layout etc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "uuid": "^9.0.1"
       },
       "devDependencies": {
+        "@types/node": "^20.8.6",
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
         "@types/uuid": "^9.0.4",
@@ -1632,6 +1633,15 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.8.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.6.tgz",
+      "integrity": "sha512-eWO4K2Ji70QzKUqRy6oyJWUeB7+g2cRagT3T/nxYibYcT4y2BDL8lqolRXjTHmkZCdJfIPaY73KbJAZmcryxTQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
     },
     "node_modules/@types/offscreencanvas": {
       "version": "2019.7.1",
@@ -4368,6 +4378,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.25.3",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
+      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==",
+      "dev": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
+    "@types/node": "^20.8.6",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@types/uuid": "^9.0.4",

--- a/src/api/fetchDb.ts
+++ b/src/api/fetchDb.ts
@@ -146,13 +146,10 @@ export async function getPicPaths(): Promise<string[]>{
     const result:any = await response.json();
     const parsedBody:any = typeof result.body === "string" ? JSON.parse(result.body) : result.body;
     if (parsedBody && Array.isArray(parsedBody.file_paths) && parsedBody.file_paths.every(item => typeof item === 'string')) {
-        console.log("parsedBody")
-        console.log(parsedBody)
-
+        
         // 古い写真から順番に格納されているのが前提。逆順にすることで、最新画像を先頭にする
         const reversedPaths = [...parsedBody.file_paths].reverse();
-
-        // todo:k.ito 不適切な画像を排除するロジック追加
+        
         return reversedPaths;
     } else {
         throw new Error("Unexpected data structure");

--- a/src/assets/ngPaths.txt
+++ b/src/assets/ngPaths.txt
@@ -1,0 +1,2 @@
+DEI5.png
+DEI6.png

--- a/src/assets/ngPaths.txt
+++ b/src/assets/ngPaths.txt
@@ -1,2 +1,0 @@
-DEI5.png
-DEI6.png

--- a/src/gallery/App.css
+++ b/src/gallery/App.css
@@ -6,9 +6,22 @@
 
 .canvas {
   margin: 0;
-  padding: 0;;
+  padding: 0;
   user-select: none;
   background-color: #000000;
+}
+
+.picListContainer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  overflow: auto;
+}
+
+.picListItem {
+  max-width: 400px;
+  height: auto;
+  margin: 0 5px;
 }
 
 .addBt {

--- a/src/gallery/App.tsx
+++ b/src/gallery/App.tsx
@@ -101,7 +101,7 @@ function App() {
 
   return(
     <div className='canvas'>
-        <PicList />
+      <PicList />
       <DisplayInfo ringCount={ringCount} latestLocationJp={latestLocationJp} />
     </div>
   );

--- a/src/gallery/App.tsx
+++ b/src/gallery/App.tsx
@@ -21,6 +21,8 @@ function App() {
   } = useContext(DbContext);
 
   const dispatch = useDispatch<AppDispatch>();
+  
+  const [photoCount, setPhotCount] = useState<number>(0);
 
   // リングの表示を行う
   useEffect(() => {
@@ -101,8 +103,11 @@ function App() {
 
   return(
     <div className='canvas'>
-      <PicList />
-      <DisplayInfo ringCount={ringCount} latestLocationJp={latestLocationJp} />
+      <PicList updatePhotoCount={setPhotCount} />
+      <DisplayInfo 
+        ringCount={ringCount} 
+        latestLocationJp={latestLocationJp}
+        photoCount={photoCount} />
     </div>
   );
 }

--- a/src/gallery/components/DisplayInfo.tsx
+++ b/src/gallery/components/DisplayInfo.tsx
@@ -1,27 +1,18 @@
 import "../App.css";
-import { useAppSelector } from "../redux/store";
 
 interface DisplayInfoProps {
-    ringCount: number;
-    latestLocationJp: string | null;
-    photoCount: number;  // photoCountをpropsに追加
+    photoCount: number;
 }
 
 function DisplayInfo(props: DisplayInfoProps) {
     const {
-        ringCount,
-        latestLocationJp,
         photoCount
     } = props;
-
-    const updateTime  = useAppSelector((state) => state.updateTime.value);
     
     return (
         <>
             <div className="time-info">
                 <div>撮影枚数: {photoCount}枚</div>
-                <div className="last-update">最終更新日時: {updateTime || "不明" }</div>
-                <div>最終更新場所: {latestLocationJp ?? "不明"}</div>
             </div>
         </>
     )

--- a/src/gallery/components/DisplayInfo.tsx
+++ b/src/gallery/components/DisplayInfo.tsx
@@ -16,7 +16,6 @@ function DisplayInfo(props: DisplayInfoProps) {
 
     const updateTime  = useAppSelector((state) => state.updateTime.value);
     
-    //todo:k.ito 動的に撮影枚数を表示する処理を組み込む
     return (
         <>
             <div className="time-info">

--- a/src/gallery/components/DisplayInfo.tsx
+++ b/src/gallery/components/DisplayInfo.tsx
@@ -1,10 +1,17 @@
 import "../App.css";
 import { useAppSelector } from "../redux/store";
 
-function DisplayInfo(props: { ringCount: number, latestLocationJp: string | null}) {
+interface DisplayInfoProps {
+    ringCount: number;
+    latestLocationJp: string | null;
+    photoCount: number;  // photoCountをpropsに追加
+}
+
+function DisplayInfo(props: DisplayInfoProps) {
     const {
         ringCount,
-        latestLocationJp
+        latestLocationJp,
+        photoCount
     } = props;
 
     const updateTime  = useAppSelector((state) => state.updateTime.value);
@@ -13,7 +20,7 @@ function DisplayInfo(props: { ringCount: number, latestLocationJp: string | null
     return (
         <>
             <div className="time-info">
-                <div>撮影枚数: 40枚</div>
+                <div>撮影枚数: {photoCount}枚</div>
                 <div className="last-update">最終更新日時: {updateTime || "不明" }</div>
                 <div>最終更新場所: {latestLocationJp ?? "不明"}</div>
             </div>

--- a/src/gallery/components/PicList.tsx
+++ b/src/gallery/components/PicList.tsx
@@ -10,17 +10,9 @@ function PicList({updatePhotoCount}: PicListProps) {
 
   useEffect(() => {
     getPicPaths().then(async (data) => {
-      
-      // テキストファイルから不適切な画像のリストを読み込む
-      const NgPaths: string[] = await fetchNgPaths();
-
-      // 不適切な画像を排除する
-      const validData = data.filter(path => {
-        return !NgPaths.some(ngPath => path.includes(ngPath));
-      });
 
       // 下記２行は表示テスト用。４枚のサンプルデータを40枚に増やした
-      const multipliedData = validData.flatMap(pic => Array(10).fill(pic));
+      const multipliedData = data.flatMap(pic => Array(10).fill(pic));
       setPics(multipliedData);
       // setPics(validData); // 本番コード
 
@@ -44,15 +36,4 @@ function PicList({updatePhotoCount}: PicListProps) {
   );
 }
 
-// テキストファイルを読み込む関数
-async function fetchNgPaths(): Promise<string[]> {
-  const response = await fetch("../assets/ngPaths.txt");
-  if(!response.ok){
-      return [];
-  }
-  
-  const text = await response.text();
-  // テキストファイルの各行を配列として取得
-  return text.split('\n').map(line => line.trim()).filter(line => line);
-}
 export default PicList;

--- a/src/gallery/components/PicList.tsx
+++ b/src/gallery/components/PicList.tsx
@@ -9,21 +9,28 @@ function PicList({updatePhotoCount}: PicListProps) {
   const [picPaths, setPics] = useState<string[]>([]);
 
   useEffect(() => {
-    getPicPaths().then((data) => {
+    getPicPaths().then(async (data) => {
       
+      // テキストファイルから不適切な画像のリストを読み込む
+      const NgPaths: string[] = await fetchNgPaths();
+
+      // 不適切な画像を排除する
+      const validData = data.filter(path => {
+        return !NgPaths.some(ngPath => path.includes(ngPath));
+      });
+
       // 下記２行は表示テスト用。４枚のサンプルデータを40枚に増やした
-      const multipliedData = data.flatMap(pic => Array(10).fill(pic));
+      const multipliedData = validData.flatMap(pic => Array(10).fill(pic));
       setPics(multipliedData);
-      // setPics(data); // 本番コード
+      // setPics(validData); // 本番コード
 
       updatePhotoCount(multipliedData.length);
 
-      //updatePhotoCount(data.length); // 本番コード
+      //updatePhotoCount(validData.length); // 本番コード
     })
   }, [updatePhotoCount]);
 
   const baseUrl = "https://we-are-what-we-do.s3.ap-northeast-1.amazonaws.com/";
-  console.log(picPaths);
   return (
     <div className="picListContainer">
       {picPaths.map((picPath, index) => (
@@ -35,5 +42,17 @@ function PicList({updatePhotoCount}: PicListProps) {
       ))}
     </div>
   );
+}
+
+// テキストファイルを読み込む関数
+async function fetchNgPaths(): Promise<string[]> {
+  const response = await fetch("../assets/ngPaths.txt");
+  if(!response.ok){
+      return [];
+  }
+  
+  const text = await response.text();
+  // テキストファイルの各行を配列として取得
+  return text.split('\n').map(line => line.trim()).filter(line => line);
 }
 export default PicList;

--- a/src/gallery/components/PicList.tsx
+++ b/src/gallery/components/PicList.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useState } from "react";
 import { getPicPaths } from "../../api/fetchDb";
 
+interface PicListProps {
+  updatePhotoCount: (count: number) => void;
+}
 
-function PicList() {
+function PicList({updatePhotoCount}: PicListProps) {
   const [picPaths, setPics] = useState<string[]>([]);
 
   useEffect(() => {
@@ -11,9 +14,13 @@ function PicList() {
       // 下記２行は表示テスト用。４枚のサンプルデータを40枚に増やした
       const multipliedData = data.flatMap(pic => Array(10).fill(pic));
       setPics(multipliedData);
-      // setPics(data);
+      // setPics(data); // 本番コード
+
+      updatePhotoCount(multipliedData.length);
+
+      //updatePhotoCount(data.length); // 本番コード
     })
-  }, []);
+  }, [updatePhotoCount]);
 
   const baseUrl = "https://we-are-what-we-do.s3.ap-northeast-1.amazonaws.com/";
   console.log(picPaths);

--- a/src/gallery/components/PicList.tsx
+++ b/src/gallery/components/PicList.tsx
@@ -18,13 +18,13 @@ function PicList() {
   const baseUrl = "https://we-are-what-we-do.s3.ap-northeast-1.amazonaws.com/";
   console.log(picPaths);
   return (
-    <div style={{ overflow: 'auto' }}>
+    <div className="picListContainer">
       {picPaths.map((picPath, index) => (
         <img 
           key={index} 
           src={`${baseUrl}${picPath}`} 
           alt={`pic-${index}`}
-          style={{ maxWidth: '400px', height: 'auto' }}/>
+          className="picListItem"/>
       ))}
     </div>
   );


### PR DESCRIPTION
・撮影枚数を動的に表示する仕組み実装
・写真を中央に寄せて表示

## 注意
・不適切な画像を排除するロジックを実装できなかった
最初は下記の実装を考えていた。
assetsフォルダ配下にngPaths.txtを配置。各行に排除したい画像パスを記入。例）DEI6.png
ファイルを解析して、NG画像を表示しないようにした。
しかしこの方法だと、テキストファイルを更新して、その中身をアプリに反映させるためには
アプリのリビルドと再デプロイが必要となりそうだったので、実装しなかった。
サーバー側で不適切な画像を排除するロジックを実装してもらえないだろうか。

もしくはpublicフォルダにアクセスできるようになれば、publicフォルダにテキストファイルを置いて、
その動きが実現できる気はしている。
